### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,43 +1,43 @@
 {
-    "name":                         "grunt-magic-paths",
-    "description":                  "Magical asset paths for your HTML templates.",
-    "version":                      "0.1.0",
-    "homepage":                     "https://github.com/ben-eb/grunt-magic-paths",
+    "name": "grunt-magic-paths",
+    "description": "Magical asset paths for your HTML templates.",
+    "version": "0.1.0",
+    "homepage": "https://github.com/ben-eb/grunt-magic-paths",
     "author": {
-        "name":                     "Ben Briggs",
-        "email":                    "therealbenbriggs@hotmail.com",
-        "url":                      "http://beneb.info"
+        "name": "Ben Briggs",
+        "email": "therealbenbriggs@hotmail.com",
+        "url": "http://beneb.info"
     },
     "repository": {
-        "type":                     "git",
-        "url":                      "git://github.com/ben-eb/grunt-magic-paths.git"
+        "type": "git",
+        "url": "git://github.com/ben-eb/grunt-magic-paths.git"
     },
     "bugs": {
-        "url":                      "https://github.com/ben-eb/grunt-magic-paths/issues"
+        "url": "https://github.com/ben-eb/grunt-magic-paths/issues"
     },
     "licenses": [
         {
-            "type":                 "MIT",
-            "url":                  "https://github.com/ben-eb/grunt-magic-paths/blob/master/LICENSE-MIT"
+            "type": "MIT",
+            "url": "https://github.com/ben-eb/grunt-magic-paths/blob/master/LICENSE-MIT"
         }
     ],
-    "main":                         "Gruntfile.js",
+    "main": "Gruntfile.js",
     "engines": {
-        "node":                     ">= 0.8.0"
+        "node": ">= 0.8.0"
     },
     "scripts": {
-        "test":                     "grunt test"
+        "test": "grunt test"
     },
     "devDependencies": {
-        "grunt-contrib-jshint"   :  "~0.6.0",
-        "grunt-contrib-clean"    :  "~0.4.0",
-        "grunt-contrib-nodeunit" :  "~0.2.0",
-        "grunt-lintspaces"       :  "~0.2.202",
-        "grunt"                  :  "~0.4.1",
-        "load-grunt-tasks"       :  "~0.1.0"
+        "grunt-contrib-jshint": "~0.6.0",
+        "grunt-contrib-clean": "~0.4.0",
+        "grunt-contrib-nodeunit": "~0.2.0",
+        "grunt-lintspaces": "~0.2.202",
+        "grunt": "~0.4.1",
+        "load-grunt-tasks": "~0.1.0"
     },
     "peerDependencies": {
-        "grunt":                    "~0.4.1"
+        "grunt": ">=0.4.0"
     },
     "keywords": [
         "gruntplugin"


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0


Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
